### PR TITLE
[1/2] Create simple image upload container and hook it up to API

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "prettier": "^2.1.2"
   },
   "dependencies": {
+    "@ant-design/icons": "^4.2.2",
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,35 @@
-import React, { FunctionComponent } from 'react';
+import React, { PureComponent } from 'react';
 
 import ImageContainer from './containers/ImageContainer';
 import ImageUploadContainer from './containers/ImageUploadContainer';
 
 import 'antd/dist/antd.css';
 
-const App: FunctionComponent = () => (
-  <>
-    <ImageContainer />
-    <ImageUploadContainer />
-  </>
-);
+interface Props {}
+
+class App extends PureComponent<Props> {
+  private imageContainer: ImageContainer | null = null;
+
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <>
+        <ImageContainer
+          ref={(instance) => {
+            this.imageContainer = instance;
+          }}
+        />
+        <ImageUploadContainer
+          onUploadedCallback={() => {
+            this.imageContainer?.fetchImages();
+          }}
+        />
+      </>
+    );
+  }
+}
 
 export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent } from 'react';
 
-import ControlPanelContainer from './containers/ControlPanelContainer';
+import ImageUploadContainer from './containers/ImageUploadContainer';
 
 import 'antd/dist/antd.css';
 
-const App: FunctionComponent = () => <ControlPanelContainer />;
+const App: FunctionComponent = () => <ImageUploadContainer />;
 
 export default App;

--- a/frontend/src/containers/ImageContainer.tsx
+++ b/frontend/src/containers/ImageContainer.tsx
@@ -17,13 +17,17 @@ class ImageContainer extends PureComponent<Props, State> {
     super(props);
 
     this.state = { images: [] };
+
+    this.fetchImages = this.fetchImages.bind(this);
   }
 
   componentDidMount() {
+    this.fetchImages();
+  }
+
+  fetchImages() {
     getImages().then((result) => {
-      this.setState({
-        images: result,
-      });
+      this.setState({ images: result });
     });
   }
 

--- a/frontend/src/containers/ImageUploadContainer.tsx
+++ b/frontend/src/containers/ImageUploadContainer.tsx
@@ -1,21 +1,15 @@
 import React, { PureComponent } from 'react';
 
-import { LoadingOutlined, PlusOutlined } from '@ant-design/icons';
-import Upload, { UploadChangeParam } from 'antd/es/upload';
-import styled from 'styled-components';
+import { LoadingOutlined, UploadOutlined } from '@ant-design/icons';
+import { Button, Upload, message } from 'antd';
+import { UploadChangeParam } from 'antd/es/upload';
 
-const UploadContainer = styled.div`
-  .ant-upload {
-    width: 200px;
-    height: 200px;
-  }
-`;
-
-interface Props {}
+interface Props {
+  onUploadedCallback?: () => void;
+}
 
 interface State {
   loading: boolean;
-  imageUrl?: string;
 }
 
 class ImageUploadComponent extends PureComponent<Props, State> {
@@ -42,43 +36,33 @@ class ImageUploadComponent extends PureComponent<Props, State> {
 
         const reader = new FileReader();
         reader.addEventListener('load', () => {
-          this.setState({ loading: false, imageUrl: reader.result as string });
+          this.setState({ loading: false });
+          message.info(`${info.file.name} uploaded.`);
+          this.props.onUploadedCallback?.();
         });
         reader.readAsDataURL(image);
+        break;
+      case 'error':
+        message.error(`${info.file.name} file upload failed.`);
+        this.setState({ loading: false });
         break;
     }
   }
 
-  renderUploadButton() {
-    const { loading, imageUrl } = this.state;
-
-    if (imageUrl) {
-      return (
-        <img src={imageUrl} alt="Uploaded image" style={{ maxWidth: '100%', maxHeight: '100%' }} />
-      );
-    }
-
-    return (
-      <div>
-        {loading ? <LoadingOutlined /> : <PlusOutlined />}
-        <div style={{ marginTop: 8 }}>Upload</div>
-      </div>
-    );
-  }
-
   render() {
+    const { loading } = this.state;
+
     return (
-      <UploadContainer>
-        <Upload
-          accept="image/*"
-          action="http://127.0.0.1:5000/api/images"
-          listType="picture-card"
-          showUploadList={false}
-          onChange={this.handleChange}
-        >
-          {this.renderUploadButton()}
-        </Upload>
-      </UploadContainer>
+      <Upload
+        accept="image/*"
+        action="http://127.0.0.1:5000/api/images"
+        showUploadList={false}
+        onChange={this.handleChange}
+      >
+        <Button icon={loading ? <LoadingOutlined /> : <UploadOutlined />} disabled={loading}>
+          Click to Upload
+        </Button>
+      </Upload>
     );
   }
 }

--- a/frontend/src/containers/ImageUploadContainer.tsx
+++ b/frontend/src/containers/ImageUploadContainer.tsx
@@ -4,6 +4,8 @@ import { LoadingOutlined, UploadOutlined } from '@ant-design/icons';
 import { Button, Upload, message } from 'antd';
 import { UploadChangeParam } from 'antd/es/upload';
 
+import { IMAGE_API } from '../data/ApiConstants';
+
 interface Props {
   onUploadedCallback?: () => void;
 }
@@ -55,7 +57,7 @@ class ImageUploadComponent extends PureComponent<Props, State> {
     return (
       <Upload
         accept="image/*"
-        action="http://127.0.0.1:5000/api/images"
+        action={IMAGE_API}
         showUploadList={false}
         onChange={this.handleChange}
       >

--- a/frontend/src/containers/ImageUploadContainer.tsx
+++ b/frontend/src/containers/ImageUploadContainer.tsx
@@ -1,0 +1,86 @@
+import React, { PureComponent } from 'react';
+
+import { LoadingOutlined, PlusOutlined } from '@ant-design/icons';
+import Upload, { UploadChangeParam } from 'antd/es/upload';
+import styled from 'styled-components';
+
+const UploadContainer = styled.div`
+  .ant-upload {
+    width: 200px;
+    height: 200px;
+  }
+`;
+
+interface Props {}
+
+interface State {
+  loading: boolean;
+  imageUrl?: string;
+}
+
+class ImageUploadComponent extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = { loading: false };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(info: UploadChangeParam) {
+    switch (info.file.status) {
+      case 'uploading':
+        if (!this.state.loading) {
+          this.setState({ loading: true });
+        }
+        break;
+      case 'done':
+        const image = info.file.originFileObj;
+        if (!image) {
+          return;
+        }
+
+        const reader = new FileReader();
+        reader.addEventListener('load', () => {
+          this.setState({ loading: false, imageUrl: reader.result as string });
+        });
+        reader.readAsDataURL(image);
+        break;
+    }
+  }
+
+  renderUploadButton() {
+    const { loading, imageUrl } = this.state;
+
+    if (imageUrl) {
+      return (
+        <img src={imageUrl} alt="Uploaded image" style={{ maxWidth: '100%', maxHeight: '100%' }} />
+      );
+    }
+
+    return (
+      <div>
+        {loading ? <LoadingOutlined /> : <PlusOutlined />}
+        <div style={{ marginTop: 8 }}>Upload</div>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <UploadContainer>
+        <Upload
+          accept="image/*"
+          action="http://127.0.0.1:5000/api/images"
+          listType="picture-card"
+          showUploadList={false}
+          onChange={this.handleChange}
+        >
+          {this.renderUploadButton()}
+        </Upload>
+      </UploadContainer>
+    );
+  }
+}
+
+export default ImageUploadComponent;

--- a/server/server/app.py
+++ b/server/server/app.py
@@ -43,7 +43,7 @@ def get_image(imageId):
 
 @app.route("/api/images", methods=["POST"])
 def upload_image():
-    image_upload = request.files["image"]
+    image_upload = request.files["file"]
 
     filename = secure_filename(image_upload.filename)
     extension = os.path.splitext(filename)[1]


### PR DESCRIPTION
This adds a simple upload handler using Ant's Upload component and links up the action and uploading state to the image upload API. Next step for this is to make it look nicer and more consistent with #17 and to add a bit more customization on top of Ant's defaults.

Also once #17 is merged, I'll start using the constants defined in there to configure this component.

Depends on #18. Part of #12. @jbewing 