### PR TITLE
Add a first cut at an image generation script

### DIFF
--- a/server/image_processor.py
+++ b/server/image_processor.py
@@ -5,6 +5,7 @@ from PIL import Image
 size = 35, 35
 angular_segments_count = 120
 angular_segments = 360 / angular_segments_count
+size_over_2 = int(size[0]/2)
 
 
 def process_image_for_mcu(image_file):
@@ -18,7 +19,7 @@ def process_image_for_mcu(image_file):
     for theta in range(angular_segments_count):
         copied_image = image.copy()
         rotated_image = copied_image.rotate((360/angular_segments_count) * theta)
-        pixels = list(rotated_image.getdata())[(35 * 17):(35 * 17) + 35]
+        pixels = list(rotated_image.getdata())[(size[0] * size_over_2):(size[0] * size_over_2) + size[0]]
         for i in range(len(pixels)):
             output_pixels[i].append(pixels[i])
 
@@ -26,13 +27,18 @@ def process_image_for_mcu(image_file):
 
 
 def print_pixels_as_mcu_code(rgb_data):
-    print('.ledValues = {\n')
+    # Construct a C-style array initialization line for each row of the pixels
+    crgb_array_literal_rows = list()
     for row in rgb_data:
-        crgbSrings = list(map(lambda pixel: f"CRGB({pixel[0]},{pixel[1]},{pixel[2]})", row))
-        print(f"{{{','.join(crgbSrings)}}},")
+        crgbSrings = list(map(lambda pixel: f'CRGB({pixel[0]},{pixel[1]},{pixel[2]})', row))
+        crgb_array_literal_rows.append('{' + ','.join(crgbSrings) + '}')
+
+    # Print the C-struct initialization statement and join all the array initialization literals together
+    print('.ledValues = {')
+    print(',\n'.join(crgb_array_literal_rows))
     print('}')
 
 
 if __name__ == '__main__':
     the_pixels = process_image_for_mcu(sys.argv[1])
-    print_pixels_as_mcu_code(thePixels)
+    print_pixels_as_mcu_code(the_pixels)

--- a/server/image_processor.py
+++ b/server/image_processor.py
@@ -6,21 +6,22 @@ size = 35, 35
 angular_segments_count = 120
 angular_segments = 360 / angular_segments_count
 
+
 def process_image_for_mcu(image_file):
     image = Image.open(image_file)
     image.thumbnail(size)
 
     output_pixels = [[]] * size[0]
 
-    for _ in range(angular_segments_count):
-        pixels = list(image.getdata())[35 * (17):35 * 17 + 35]
+    for theta in range(angular_segments_count):
+        copied_image = image.copy()
+        copied_image.rotate((360/angular_segments_count) * theta)
+        pixels = list(copied_image.getdata())[35 * (17):35 * 17 + 35]
         for i in range(len(pixels)):
             output_pixels[i].append(pixels[i])
 
-        # rotate the image for next "rendering"
-        image.rotate(360/angular_segments_count)
-
     return output_pixels
+
 
 def print_pixels_as_mcu_code(rgb_data):
     print('.ledValues = {\n')
@@ -28,6 +29,7 @@ def print_pixels_as_mcu_code(rgb_data):
         crgbSrings = list(map(lambda pixel: f"CRGB({pixel[0]},{pixel[1]},{pixel[2]})", row))
         print(f"{{ {','.join(crgbSrings)} }},")
     print('}')
+
 
 if __name__ == '__main__':
     thePixels = process_image_for_mcu(sys.argv[1])

--- a/server/image_processor.py
+++ b/server/image_processor.py
@@ -11,12 +11,14 @@ def process_image_for_mcu(image_file):
     image = Image.open(image_file)
     image.thumbnail(size)
 
-    output_pixels = [[]] * size[0]
+    output_pixels = []
+    for j in range(size[0]):
+        output_pixels.append([])
 
     for theta in range(angular_segments_count):
         copied_image = image.copy()
-        copied_image.rotate((360/angular_segments_count) * theta)
-        pixels = list(copied_image.getdata())[35 * (17):35 * 17 + 35]
+        rotated_image = copied_image.rotate((360/angular_segments_count) * theta)
+        pixels = list(rotated_image.getdata())[(35 * 17):(35 * 17) + 35]
         for i in range(len(pixels)):
             output_pixels[i].append(pixels[i])
 
@@ -27,7 +29,7 @@ def print_pixels_as_mcu_code(rgb_data):
     print('.ledValues = {\n')
     for row in rgb_data:
         crgbSrings = list(map(lambda pixel: f"CRGB({pixel[0]},{pixel[1]},{pixel[2]})", row))
-        print(f"{{ {','.join(crgbSrings)} }},")
+        print(f"{{{','.join(crgbSrings)}}},")
     print('}')
 
 

--- a/server/image_processor.py
+++ b/server/image_processor.py
@@ -34,5 +34,5 @@ def print_pixels_as_mcu_code(rgb_data):
 
 
 if __name__ == '__main__':
-    thePixels = process_image_for_mcu(sys.argv[1])
+    the_pixels = process_image_for_mcu(sys.argv[1])
     print_pixels_as_mcu_code(thePixels)

--- a/server/image_processor.py
+++ b/server/image_processor.py
@@ -1,0 +1,34 @@
+import sys
+
+from PIL import Image
+
+size = 35, 35
+angular_segments_count = 120
+angular_segments = 360 / angular_segments_count
+
+def process_image_for_mcu(image_file):
+    image = Image.open(image_file)
+    image.thumbnail(size)
+
+    output_pixels = [[]] * size[0]
+
+    for _ in range(angular_segments_count):
+        pixels = list(image.getdata())[35 * (17):35 * 17 + 35]
+        for i in range(len(pixels)):
+            output_pixels[i].append(pixels[i])
+
+        # rotate the image for next "rendering"
+        image.rotate(360/angular_segments_count)
+
+    return output_pixels
+
+def print_pixels_as_mcu_code(rgb_data):
+    print('.ledValues = {\n')
+    for row in rgb_data:
+        crgbSrings = list(map(lambda pixel: f"CRGB({pixel[0]},{pixel[1]},{pixel[2]})", row))
+        print(f"{{ {','.join(crgbSrings)} }},")
+    print('}')
+
+if __name__ == '__main__':
+    thePixels = process_image_for_mcu(sys.argv[1])
+    print_pixels_as_mcu_code(thePixels)

--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -208,6 +208,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.8.0"
 
 [[package]]
+category = "main"
+description = "Python Imaging Library (Fork)"
+name = "pillow"
+optional = false
+python-versions = ">=3.6"
+version = "8.0.1"
+
+[[package]]
 category = "dev"
 description = "Cross-platform lib for process and system monitoring in Python."
 name = "psutil"
@@ -333,7 +341,7 @@ dev = ["pytest", "pytest-timeout", "coverage", "tox", "sphinx", "pallets-sphinx-
 watchdog = ["watchdog"]
 
 [metadata]
-content-hash = "c3d7df5a67fd9ba23be95f66d99b19d5dd112b4a74abd837973580229358a8a5"
+content-hash = "603dd76f6c96065976e5b2d906d4b53f34f7235a8793538b26e28aee80ca84f6"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -435,6 +443,36 @@ mypy-extensions = [
 pathspec = [
     {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
     {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
+]
+pillow = [
+    {file = "Pillow-8.0.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:b63d4ff734263ae4ce6593798bcfee6dbfb00523c82753a3a03cbc05555a9cc3"},
+    {file = "Pillow-8.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5f9403af9c790cc18411ea398a6950ee2def2a830ad0cfe6dc9122e6d528b302"},
+    {file = "Pillow-8.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6b4a8fd632b4ebee28282a9fef4c341835a1aa8671e2770b6f89adc8e8c2703c"},
+    {file = "Pillow-8.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:cc3ea6b23954da84dbee8025c616040d9aa5eaf34ea6895a0a762ee9d3e12e11"},
+    {file = "Pillow-8.0.1-cp36-cp36m-win32.whl", hash = "sha256:d8a96747df78cda35980905bf26e72960cba6d355ace4780d4bdde3b217cdf1e"},
+    {file = "Pillow-8.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:7ba0ba61252ab23052e642abdb17fd08fdcfdbbf3b74c969a30c58ac1ade7cd3"},
+    {file = "Pillow-8.0.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:795e91a60f291e75de2e20e6bdd67770f793c8605b553cb6e4387ce0cb302e09"},
+    {file = "Pillow-8.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0a2e8d03787ec7ad71dc18aec9367c946ef8ef50e1e78c71f743bc3a770f9fae"},
+    {file = "Pillow-8.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:006de60d7580d81f4a1a7e9f0173dc90a932e3905cc4d47ea909bc946302311a"},
+    {file = "Pillow-8.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:bd7bf289e05470b1bc74889d1466d9ad4a56d201f24397557b6f65c24a6844b8"},
+    {file = "Pillow-8.0.1-cp37-cp37m-win32.whl", hash = "sha256:95edb1ed513e68bddc2aee3de66ceaf743590bf16c023fb9977adc4be15bd3f0"},
+    {file = "Pillow-8.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:e38d58d9138ef972fceb7aeec4be02e3f01d383723965bfcef14d174c8ccd039"},
+    {file = "Pillow-8.0.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:d3d07c86d4efa1facdf32aa878bd508c0dc4f87c48125cc16b937baa4e5b5e11"},
+    {file = "Pillow-8.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:fbd922f702582cb0d71ef94442bfca57624352622d75e3be7a1e7e9360b07e72"},
+    {file = "Pillow-8.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:92c882b70a40c79de9f5294dc99390671e07fc0b0113d472cbea3fde15db1792"},
+    {file = "Pillow-8.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7c9401e68730d6c4245b8e361d3d13e1035cbc94db86b49dc7da8bec235d0015"},
+    {file = "Pillow-8.0.1-cp38-cp38-win32.whl", hash = "sha256:6c1aca8231625115104a06e4389fcd9ec88f0c9befbabd80dc206c35561be271"},
+    {file = "Pillow-8.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:cc9ec588c6ef3a1325fa032ec14d97b7309db493782ea8c304666fb10c3bd9a7"},
+    {file = "Pillow-8.0.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:eb472586374dc66b31e36e14720747595c2b265ae962987261f044e5cce644b5"},
+    {file = "Pillow-8.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:0eeeae397e5a79dc088d8297a4c2c6f901f8fb30db47795113a4a605d0f1e5ce"},
+    {file = "Pillow-8.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:81f812d8f5e8a09b246515fac141e9d10113229bc33ea073fec11403b016bcf3"},
+    {file = "Pillow-8.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:895d54c0ddc78a478c80f9c438579ac15f3e27bf442c2a9aa74d41d0e4d12544"},
+    {file = "Pillow-8.0.1-cp39-cp39-win32.whl", hash = "sha256:2fb113757a369a6cdb189f8df3226e995acfed0a8919a72416626af1a0a71140"},
+    {file = "Pillow-8.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:59e903ca800c8cfd1ebe482349ec7c35687b95e98cefae213e271c8c7fffa021"},
+    {file = "Pillow-8.0.1-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:5abd653a23c35d980b332bc0431d39663b1709d64142e3652890df4c9b6970f6"},
+    {file = "Pillow-8.0.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:4b0ef2470c4979e345e4e0cc1bbac65fda11d0d7b789dbac035e4c6ce3f98adb"},
+    {file = "Pillow-8.0.1-pp37-pypy37_pp73-win32.whl", hash = "sha256:8de332053707c80963b589b22f8e0229f1be1f3ca862a932c1bcd48dafb18dd8"},
+    {file = "Pillow-8.0.1.tar.gz", hash = "sha256:11c5c6e9b02c9dac08af04f093eb5a2f84857df70a7d4a6a6ad461aca803fb9e"},
 ]
 psutil = [
     {file = "psutil-5.7.2-cp27-none-win32.whl", hash = "sha256:f2018461733b23f308c298653c8903d32aaad7873d25e1d228765e91ae42c3f2"},

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -27,6 +27,7 @@ gpiozero = "^1.5.1"
 Flask-SQLAlchemy = "^2.4.4"
 Flask-Migrate = "^2.5.3"
 flask-cors = "^3.0.9"
+Pillow = "^8.0.1"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"


### PR DESCRIPTION
This PR adds a script that processes an arbitrary image for the PoV display and outputs the necessary C code such that the processed data can be shown on the MCU.

I apologize for writing this. The algorithm is generally as follows at the moment:
- Take the segment of pixels in the right center of a thumbnailed view of the original image
- Save those
- Rotate the image 3 degrees (relative to the OG image i.e. only one "rotation" operation is performed from the base image to prevent tearing from successive rotation transformations)
- loop until we've gone 360 degrees
- output these processed images so that they can be copy-pasta'd into the MCU source

##### Usage

```bash
poetry run python image_processor.py <path_to_image>
# Example:
poetry run python image_processor.py /Users/jbewing/Desktop/a_golden_retriever.jpeg
# Most likely worth it to redirect output to a file as they get _quite_ large
run python image_processor.py /Users/jbewing/Desktop/a_golden_retriever.jpeg > /Users/jbewing/Desktop/golden_retriever_pov_pixels.txt
```

cc @DarkAce65 @brodigan-e 
Related to: https://github.com/brodigan-e/capstone-POV/issues/9