### PR TITLE
Process all images uploaded to the web server by default

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,10 +20,6 @@ interface Props {}
 class App extends PureComponent<Props> {
   private imageContainer: ImageContainer | null = null;
 
-  constructor(props: Props) {
-    super(props);
-  }
-
   render() {
     return (
       <Layout style={{ height: '100%' }}>

--- a/server/server/__init__.py
+++ b/server/server/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask
 from flask_cors import CORS
 from flask_migrate import Migrate
@@ -7,7 +9,17 @@ app = Flask(__name__)
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///db.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = True
 app.config["IMAGE_UPLOAD_FOLDER"] = "image-uploads/"
+app.config["PROCESSED_IMAGE_FOLDER"] = "image-processed/"
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 CORS(app)
 
+
+def create_folders_if_not_exists(folders):
+    for folder in folders:
+        folder_path = os.path.join(app.instance_path, folder)
+        if not os.path.exists(folder_path):
+            os.mkdir(folder_path)
+
+
+create_folders_if_not_exists([app.config["IMAGE_UPLOAD_FOLDER"], app.config["PROCESSED_IMAGE_FOLDER"]])

--- a/server/server/app.py
+++ b/server/server/app.py
@@ -38,7 +38,7 @@ def get_images():
 @app.route("/api/images/<int:imageId>", methods=["GET"])
 def get_image(imageId):
     image = ImageUpload.query.get_or_404(imageId)
-    return send_file(get_image_path_from_name(image.path_uuid))
+    return send_file(get_absolute_image_path_from_name(image.path_uuid))
 
 
 @app.route("/api/images", methods=["POST"])

--- a/server/server/app.py
+++ b/server/server/app.py
@@ -6,8 +6,8 @@ from flask import jsonify, request, send_file
 from werkzeug.utils import secure_filename
 
 from . import app, db
-from .models import ImageUpload
 from .image_processor import process_full_size_image_and_dump_to_file
+from .models import ImageUpload
 
 
 @app.before_first_request

--- a/server/server/app.py
+++ b/server/server/app.py
@@ -1,4 +1,3 @@
-import functools
 import os
 import uuid
 from http import HTTPStatus
@@ -8,6 +7,7 @@ from werkzeug.utils import secure_filename
 
 from . import app, db
 from .models import ImageUpload
+from .image_processor import process_full_size_image_and_dump_to_file
 
 
 @app.before_first_request
@@ -48,11 +48,19 @@ def upload_image():
     filename = secure_filename(image_upload.filename)
     extension = os.path.splitext(filename)[1]
 
-    image_path = str(uuid.uuid4()) + extension
-    image_upload.save(get_image_path_from_name(image_path))
+    image_uuid = str(uuid.uuid4());
+
+    image_path = image_uuid + extension
+
+    absolute_image_path = get_absolute_image_path_from_name(image_path)
+
+    image_upload.save(absolute_image_path)
+
+    process_full_size_image_and_dump_to_file(absolute_image_path,
+                                             get_absolute_processed_image_path_from_name(image_uuid))
 
     image_entry = ImageUpload(
-        title=secure_filename(image_upload.filename), path_uuid=image_path
+        title=secure_filename(image_upload.filename), path_uuid=image_path, isProcessed=True
     )
 
     db.session.add(image_entry)
@@ -65,8 +73,11 @@ def upload_image():
     )
 
 
-def get_image_path_from_name(file_name):
+def get_absolute_image_path_from_name(file_name):
     return os.path.join(app.instance_path, app.config["IMAGE_UPLOAD_FOLDER"], file_name)
+
+def get_absolute_processed_image_path_from_name(image_uuid):
+    return os.path.join(app.instance_path, app.config["PROCESSED_IMAGE_FOLDER"], image_uuid)
 
 
 def get_image_href_from_id(image_id):

--- a/server/server/image_processor.py
+++ b/server/server/image_processor.py
@@ -34,7 +34,7 @@ def process_full_size_image_and_dump_to_file(image_file_path, destination_path):
 def dump_image_data_to_file(rgb_data, file_path):
     with open(file_path, "w") as file:
         for row in rgb_data:
-            pixel_strings = list(map(lambda pixel: f'CRGB({pixel[0]},{pixel[1]},{pixel[2]})', row))
+            pixel_strings = list(map(lambda pixel: f'({pixel[0]},{pixel[1]},{pixel[2]})', row))
             rgb_data_through_rotation_for_pixel = ','.join(pixel_strings) + '\n'
             file.write(rgb_data_through_rotation_for_pixel)
 

--- a/server/server/image_processor.py
+++ b/server/server/image_processor.py
@@ -1,0 +1,57 @@
+import sys
+
+from PIL import Image
+
+size = 35, 35
+angular_segments_count = 120
+angular_segments = 360 / angular_segments_count
+size_over_2 = int(size[0]/2)
+
+
+def process_image_for_mcu(image_file):
+    image = Image.open(image_file)
+    image.thumbnail(size)
+
+    output_pixels = []
+    for j in range(size[0]):
+        output_pixels.append([])
+
+    for theta in range(angular_segments_count):
+        copied_image = image.copy()
+        rotated_image = copied_image.rotate((360/angular_segments_count) * theta)
+        pixels = list(rotated_image.getdata())[(size[0] * size_over_2):(size[0] * size_over_2) + size[0]]
+        for i in range(len(pixels)):
+            output_pixels[i].append(pixels[i])
+
+    return output_pixels
+
+
+def process_full_size_image_and_dump_to_file(image_file_path, destination_path):
+    rgb_data = process_image_for_mcu(image_file_path)
+    dump_image_data_to_file(rgb_data, destination_path)
+
+
+def dump_image_data_to_file(rgb_data, file_path):
+    with open(file_path, "w") as file:
+        for row in rgb_data:
+            pixel_strings = list(map(lambda pixel: f'CRGB({pixel[0]},{pixel[1]},{pixel[2]})', row))
+            rgb_data_through_rotation_for_pixel = ','.join(pixel_strings) + '\n'
+            file.write(rgb_data_through_rotation_for_pixel)
+
+
+def print_pixels_as_mcu_code(rgb_data):
+    # Construct a C-style array initialization line for each row of the pixels
+    crgb_array_literal_rows = list()
+    for row in rgb_data:
+        crgbSrings = list(map(lambda pixel: f'CRGB({pixel[0]},{pixel[1]},{pixel[2]})', row))
+        crgb_array_literal_rows.append('{' + ','.join(crgbSrings) + '}')
+
+    # Print the C-struct initialization statement and join all the array initialization literals together
+    print('.ledValues = {')
+    print(',\n'.join(crgb_array_literal_rows))
+    print('}')
+
+
+if __name__ == '__main__':
+    the_pixels = process_image_for_mcu(sys.argv[1])
+    print_pixels_as_mcu_code(the_pixels)


### PR DESCRIPTION
This PR updates the REST API to automatically process and save all images in our "optimized for the MCU" format. I was doing some slides and I really wanted to write that the REST API had the functionality of processing these images, so I just added it (to not make any misleading statements of course 😉 ).

##### Details
- Saved into image-processed/{uuid} w/ almost the exact same format as what we used to print the C-code 
- Done synchronously on upload

### Testing
I ran the following commands
```bash
$ poetry run task apply-migrations
$ poetry run task run &
$ curl -F "file=@/Users/jbewing/Desktop/a_golden_retriever.jpeg" 127.0.0.1:5000/api/images
...
$ kill %1
```

and verified that the text file was indeed created on my local filesystem.

cc @DarkAce65 
Closes: https://github.com/brodigan-e/capstone-POV/issues/9